### PR TITLE
voting-service-fix-commutative-message-handlers

### DIFF
--- a/services/voting-service/app/commands/service.py
+++ b/services/voting-service/app/commands/service.py
@@ -32,13 +32,10 @@ class VoteService:
             data.user_id,
         )
 
-        old_value = 0
-
         if existing_vote:
             if existing_vote.value == data.value:
                 return existing_vote
 
-            old_value = existing_vote.value
 
             vote = self.repo.update_vote(
                 db,
@@ -63,7 +60,6 @@ class VoteService:
             {
                 "post_id": str(post_id),
                 "user_id": str(data.user_id),
-                "old_value": old_value,
                 "new_value": data.value,
             },
         )
@@ -86,13 +82,11 @@ class VoteService:
             data.user_id,
         )
 
-        old_value = 0
 
         if existing_vote:
             if existing_vote.value == data.value:
                 return existing_vote
 
-            old_value = existing_vote.value
 
             vote = self.repo.update_vote(
                 db,
@@ -117,7 +111,6 @@ class VoteService:
             {
                 "comment_id": str(comment_id),
                 "user_id": str(data.user_id),
-                "old_value": old_value,
                 "new_value": data.value,
             },
         )

--- a/services/voting-service/app/consumer/consumer.py
+++ b/services/voting-service/app/consumer/consumer.py
@@ -79,7 +79,7 @@ def _on_message(channel, method, properties, body):
                 db=db,
                 post_id=event["post_id"],
                 user_id=event["user_id"],
-                old_value=event["old_value"],
+                #old_value=event["old_value"],
                 new_value=event["new_value"],
             )
 
@@ -88,7 +88,7 @@ def _on_message(channel, method, properties, body):
                 db=db,
                 comment_id=event["comment_id"],
                 user_id=event["user_id"],
-                old_value=event["old_value"],
+                #old_value=event["old_value"],
                 new_value=event["new_value"],
             )
 

--- a/services/voting-service/app/consumer/consumer.py
+++ b/services/voting-service/app/consumer/consumer.py
@@ -79,7 +79,6 @@ def _on_message(channel, method, properties, body):
                 db=db,
                 post_id=event["post_id"],
                 user_id=event["user_id"],
-                #old_value=event["old_value"],
                 new_value=event["new_value"],
             )
 
@@ -88,7 +87,6 @@ def _on_message(channel, method, properties, body):
                 db=db,
                 comment_id=event["comment_id"],
                 user_id=event["user_id"],
-                #old_value=event["old_value"],
                 new_value=event["new_value"],
             )
 

--- a/services/voting-service/app/consumer/consumer_service.py
+++ b/services/voting-service/app/consumer/consumer_service.py
@@ -17,15 +17,14 @@ class ConsumerService:
         db: Session,
         post_id: str,
         user_id: str,
-        old_value: int,
         new_value: int,
     ):
+        #convert from raw str to ensure correct UUID type.
         post_id = UUID(post_id)
         user_id = UUID(user_id)
 
+        # ensure summary exists
         summary = db.get(PostVoteSummary, post_id)
-
-        # make a new summary in db if there is no existing summary for that post
         if not summary:
             summary = PostVoteSummary(
                 post_id=post_id,
@@ -35,8 +34,8 @@ class ConsumerService:
             )
             db.add(summary)
 
-        # check if user allready has voted on this post before
-        existing_vote = (
+        # get current stored user vote (source of truth)
+        vote = (
             db.query(UserPostVote)
             .filter(
                 UserPostVote.post_id == post_id,
@@ -45,51 +44,55 @@ class ConsumerService:
             .first()
         )
 
-        # user has not voted on this post -> create a new one.
-        # save the userID together with postID, So that we can cheap fetch "has user voted on this post"
-        if not existing_vote:
-            existing_vote = UserPostVote(
+        old_value = vote.value if vote else 0
+
+        # idempotency check (duplicate event) return if this is a duplicate
+        if old_value == new_value:
+            db.commit()
+            return
+
+        delta = new_value - old_value
+
+        # if vote does not exist, make a new one
+        if not vote:
+            vote = UserPostVote(
                 post_id=post_id,
                 user_id=user_id,
-                value=new_value, # TODO should this be 0 or new_value - need to test
+                value=new_value,
             )
-            db.add(existing_vote)
+            db.add(vote)
+        else:
+            vote.value = new_value
 
-        # remove old vote
+        # apply summary changes
+        summary.score += delta
+
         if old_value == 1:
             summary.upvotes -= 1
-            summary.score -= 1
-
         elif old_value == -1:
             summary.downvotes -= 1
-            summary.score += 1
 
-        # apply new vote
         if new_value == 1:
             summary.upvotes += 1
-            summary.score += 1
-
         elif new_value == -1:
             summary.downvotes += 1
-            summary.score -= 1
-
-        existing_vote.value = new_value
 
         db.commit()
 
+    # a vote has been made on a comment, now the summaries should be updated
     def apply_comment_vote(
         self,
         db: Session,
         comment_id: str,
         user_id: str,
-        old_value: int,
         new_value: int,
     ):
+        #convert from raw str to ensure correct UUID type.
         comment_id = UUID(comment_id)
         user_id = UUID(user_id)
 
+        #ensure summary exists
         summary = db.get(CommentVoteSummary, comment_id)
-
         if not summary:
             summary = CommentVoteSummary(
                 comment_id=comment_id,
@@ -99,7 +102,8 @@ class ConsumerService:
             )
             db.add(summary)
 
-        existing_vote = (
+        # get current stored user vote (source of truth)
+        vote = (
             db.query(UserCommentVote)
             .filter(
                 UserCommentVote.comment_id == comment_id,
@@ -108,32 +112,37 @@ class ConsumerService:
             .first()
         )
 
-        if not existing_vote:
-            existing_vote = UserCommentVote(
+        old_value = vote.value if vote else 0
+
+        # idempotency check (duplicate event) return if this is a duplicate
+        if old_value == new_value:
+            db.commit()
+            return
+
+        delta = new_value - old_value
+
+        # if vote does not exist, make a new one
+        if not vote:
+            vote = UserCommentVote(
                 comment_id=comment_id,
                 user_id=user_id,
-                value=0,
+                value=new_value,
             )
-            db.add(existing_vote)
+            db.add(vote)
+        else:
+            vote.value = new_value
 
-        # remove old vote
+        # apply summary changes
+        summary.score += delta
+
         if old_value == 1:
             summary.upvotes -= 1
-            summary.score -= 1
-
         elif old_value == -1:
             summary.downvotes -= 1
-            summary.score += 1
 
-        # apply new vote
         if new_value == 1:
             summary.upvotes += 1
-            summary.score += 1
-
         elif new_value == -1:
             summary.downvotes += 1
-            summary.score -= 1
-
-        existing_vote.value = new_value
 
         db.commit()


### PR DESCRIPTION
removed old_value from CQRS/message flow.
no need for it since the source of truth should be the data in the DB. not some "old_value" parsed through events. that is not very commutative safe since events can be consumed in a random order.